### PR TITLE
Fix performance when we add and remove many connections.

### DIFF
--- a/signals-cpp/signal.hpp
+++ b/signals-cpp/signal.hpp
@@ -60,7 +60,8 @@ namespace signals {
                     if(i.conn.connected()) {
                         new_targets->push_back(i);
                     }
-                }            }
+                }
+            }
 
             // add the new connection to the new vector
             new_targets->emplace_back(conn, std::move(target));

--- a/signals-cpp/signal.hpp
+++ b/signals-cpp/signal.hpp
@@ -55,8 +55,12 @@ namespace signals {
 
             // copy existing targets
             if(auto t = m_targets) {
-                *new_targets = *t;
-            }
+                new_targets->reserve(t->size() + 1);
+                for(const auto& i : *t) {
+                    if(i.conn.connected()) {
+                        new_targets->push_back(i);
+                    }
+                }            }
 
             // add the new connection to the new vector
             new_targets->emplace_back(conn, std::move(target));


### PR DESCRIPTION
The dead connections were never removed from the internal vector holding them, leading to bad performance in connect() and in fire().